### PR TITLE
Remove axios and http proxy agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "convict-format-with-validator": "^6.2.0",
     "got": "^12.0.1",
     "hpagent": "^0.1.2",
-    "http-proxy-agent": "^5.0.0",
     "joi": "^17.6.0",
     "purpleteam-logger": "^2.0.0",
     "redis": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "@cucumber/cucumber": "^8.0.0-rc.3",
     "@hapi/bourne": "^2.0.0",
     "@hapi/hapi": "^20.2.1",
-    "axios": "^0.26.0",
     "convict": "^6.2.1",
     "convict-format-with-moment": "^6.2.0",
     "convict-format-with-validator": "^6.2.0",

--- a/src/api/app/models/app.emissary.js
+++ b/src/api/app/models/app.emissary.js
@@ -14,7 +14,7 @@
 // Doc: https://docs.aws.amazon.com/code-samples/latest/catalog/javascriptv3-lambda-src-MyLambdaApp-index.ts.html
 import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
 import { ServiceDiscoveryClient, ListInstancesCommand } from '@aws-sdk/client-servicediscovery';
-import axios from 'axios';
+import got from 'got';
 import HttpProxyAgent from 'http-proxy-agent';
 import Bourne from '@hapi/bourne';
 
@@ -247,10 +247,10 @@ internals.s2ContainersReady = async ({ collectionOfS2ContainerHostNamesWithPorts
     //   https://github.com/zaproxy/zaproxy/issues/3796#issuecomment-319376915
     //   https://github.com/zaproxy/zaproxy/issues/3594
     {
-      cloud() { return axios.get(`${protocol}://zap:${port}/UI`, { httpAgent: new HttpProxyAgent(`${protocol}://${mCV.appEmissaryHostName}:${mCV.appEmissaryPort}`) }); },
-      local() { return axios.get(`${protocol}://${mCV.appEmissaryHostName}:${mCV.appEmissaryPort}/UI`); }
+      cloud() { return got.get(`${protocol}://zap:${port}/UI`, { httpAgent: new HttpProxyAgent(`${protocol}://${mCV.appEmissaryHostName}:${mCV.appEmissaryPort}`) }); },
+      local() { return got.get(`${protocol}://${mCV.appEmissaryHostName}:${mCV.appEmissaryPort}/UI`); }
     }[process.env.NODE_ENV](),
-    axios.get(`http://${mCV.seleniumHostName}:${mCV.seleniumPort}/wd/hub/status`)
+    got.get(`http://${mCV.seleniumHostName}:${mCV.seleniumPort}/wd/hub/status`)
   ]);
 
   const results = await Promise.all(containerReadyPromises)

--- a/src/api/app/models/app.emissary.js
+++ b/src/api/app/models/app.emissary.js
@@ -15,7 +15,7 @@
 import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
 import { ServiceDiscoveryClient, ListInstancesCommand } from '@aws-sdk/client-servicediscovery';
 import got from 'got';
-import HttpProxyAgent from 'http-proxy-agent';
+import { HttpProxyAgent } from 'hpagent';
 import Bourne from '@hapi/bourne';
 
 // For complete sessionsProps


### PR DESCRIPTION
Fixes https://github.com/purpleteam-labs/purpleteam/issues/112

TL;DR: Removes the `axios` and `http-proxy-agent` dependency by migrating the calls to the library that us already used widely in the project.

### Checklist

* [x] I have read the contributing guidelines
* [x] I have read the documentation
* [x] I have included a descriptive Pull Request title
* [x] I have included a Pull Request description of my changes
* [x] I have included tests where/when required (see contributing guidelines)
* [ ] I have included documentation modifications/additions where/when required (see contributing guidelines)
